### PR TITLE
Update readme and sections for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # Navigate application deployment options with Cloud Foundry, Kubernetes, OpenWhisk and Istio
 
-PaaS platforms like Cloud Foundry, container orchestrators like Kubernetes, Serverless platforms like OpenWhisk and Service-mesh like Istio are all great technologies to deploy and manage your microservices on. Common wisdom says there is no such thing as too many choices, but abundance of choices can lead to analysis paralysis.  In this code, we look at deployment experience the different platforms provide, and what do we gain and loose by choosing one vs another. 
+PaaS platforms like Cloud Foundry, container orchestrators like Kubernetes, Serverless platforms like OpenWhisk and Service-mesh like Istio are all great technologies to deploy and manage your microservices on. Common wisdom says there is no such thing as too many choices, but abundance of choices can lead to analysis paralysis.  In this code, we look at deployment experience the different platforms provide, and what do we gain and lose by choosing one vs another.
 
 We start with a sample Node.js monolithic application, Flightassist, factor it into two microservices, and then use it for demonstrating and comparing various deployment technologies. A set of trade-offs and comparisions can be made between these deployment models, and this application provides a basis for those discussions.
 
 ![architecure-diagram](images/paas-containers.png)
 
-#### [Scenario One: Deploy Flightassist monolithic application on Cloud Foundry](#2-deploy-monolithic-flightassist-application-using-cloud-foundry) 
-#### [Scenario Two: Deploy Flightassist microservices on Cloud Foundry](docs/cloudfoundry.md) 
+#### [Scenario One: Deploy Flightassist monolithic application on Cloud Foundry](#2-deploy-monolithic-flightassist-application-using-cloud-foundry)
+#### [Scenario Two: Deploy Flightassist microservices on Cloud Foundry](docs/cloudfoundry.md)
 #### [Scenario Three: Deploy Flightassist microservices on Kubernetes Clusters](docs/kubernetes.md)
 #### [Scenario Four: Deploy Flightassist microservices on Istio](docs/istio.md)
 #### [Scenario Five: Deploy Flightassist microservices augmented with functions on OpenWhisk](docs/openwhisk.md)
@@ -28,18 +28,18 @@ The scenarios are accomplished by using:
 
 ## Prerequisites
 
-Register and obtain the keys for [FlightStats Developer API](https://developer.flightstats.com/signup) and [TripIt Developer API](https://www.tripit.com/developer/create) to query flight status. 
+Register and obtain the keys for [FlightStats Developer API](https://developer.flightstats.com/signup) and [TripIt Developer API](https://www.tripit.com/developer/create) to query flight status.
 
 When signing up for a FlightStats developer key, note that there is a review process that may take 24 hours or more to get your application credentials activated for a 30-day trial with the API.
 
-## Deploy using DevOps Toolchain 
+## Deploy using DevOps Toolchain
 
 Click the button to deploy your app and fill in all the variables from **Delivery Pipeline**. For Further instructions, please follow the [Toolchain instructions](https://github.com/IBM/container-journey-template/blob/master/Toolchain_Instructions_new.md).
 
 [![Create Toolchain](https://github.com/IBM/container-journey-template/blob/master/images/button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
 
 ### Toolchain Scenarios One: Monolithic Application
-You should see a link under the Cloud Foundry Deploy stage and that's where your application is hosting. 
+You should see a link under the Cloud Foundry Deploy stage and that's where your application is hosting.
 
 ### Toolchain Scenarios Two: Microservices on Kubernetes Clusters, with or without Serverless capabilities
 
@@ -55,7 +55,7 @@ Then, click **View logs and history** under Kubernetes Deploy stage in your pipe
 1. [Provision application services - Cloudant Database and Insights for Weather Service](#1-create-your-cloudant-database-and-insights-for-weather-service)
 2. [Deploy monolithic application](#2-deploy-monolithic-flightassist-application-using-cloud-foundry)
 3. [Factor monolithic application into microservices and test](#3-factor-monolithic-application-into-microservices-and-test)
- 
+
 ## Part B: Deploy microservices leveraging:
 
 4. [Cloud Foundry](docs/cloudfoundry.md)
@@ -75,7 +75,7 @@ git clone https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-a
 
 Since we need to create services using the command line, we need to install [Bluemix CLI](http://clis.ng.bluemix.net/ui/home.html) before proceeding to the following steps.
 
-We will use Bluemix's [The Cloudant NoSQL database service](https://console.ng.bluemix.net/catalog/services/cloudant-nosql-db?env_id=ibm:yp:us-south) and [Insights for Weather service](https://console.ng.bluemix.net/catalog/services/weather-company-data?env_id=ibm:yp:us-south) for our database and weather data. Therefore, run the following commands to create cloudant and Insights for Weather service. 
+We will use Bluemix's [The Cloudant NoSQL database service](https://console.ng.bluemix.net/catalog/services/cloudant-nosql-db?env_id=ibm:yp:us-south) and [Insights for Weather service](https://console.ng.bluemix.net/catalog/services/weather-company-data?env_id=ibm:yp:us-south) for our database and weather data. Therefore, run the following commands to create cloudant and Insights for Weather service.
 
 > For this example, we recommend you name your services to *mycloudant* and *myweatherinsights*.
 
@@ -109,29 +109,30 @@ Now, go to https://console.ng.bluemix.net/dashboard/apps and select your applica
    - `FLIGHTSTATS_APP_KEY` : application key assigned by FlightStats
    - `TRIPIT_API_KEY` : API key assigned by TripIt
    - `TRIPIT_API_SECRET` : API secret assigned by TripIt
-   - `BASE_URL`: You URL for accessing your application. e.g. https://{app_name}.mybluemix.net/
+   - `BASE_URL`: your URL for accessing your application. e.g. https://{app_name}.mybluemix.net/
 
 Your application should restart automatically but can be done manually as well
 in the UI. With the service bindings and added environment variables, the
 application should be operational at the hostname route you selected for your CF
-application. 
+application.
 
-Congratulation, now you can learn about [How to Use Flightassist](#how-to-use-flightassist) and start testing your application.
+Congratulations, now you can learn about [How to Use Flightassist](#how-to-use-flightassist) and start testing your application.
 
 # 3. Factor monolithic application into microservices and test
 
-To factor the application into microservices, we add a python microservice to the picture. Instead of directly accessing the apis from Node app, the python program will serve as a proxy to query. This step tests the two microservices and associated dockerfiles which are created.
+To factor the application into microservices, we add a python microservice to the picture. Instead of directly accessing the apis from Node app, the python program will serve as a proxy to query. This step locally tests the app with the microservice and associated docker container images which are created.
 
 First, install [Docker CLI](https://www.docker.com/community-edition#/download).
 
-Next, edit the `docker-compose.yaml` file and add your credentials for **FLIGHTSTATS_APP_ID**, **FLIGHTSTATS_APP_KEY**, **TRIPIT_API_KEY**,**TRIPIT_API_SECRET**,**CLOUDANT_URL**, and **WEATHER_URL**. You can run the following command to view your service credentials.
+Next, edit the `docker-compose.yaml` file and add your credentials for **FLIGHTSTATS_APP_ID**, **FLIGHTSTATS_APP_KEY**, **TRIPIT_API_KEY**,**TRIPIT_API_SECRET**,**CLOUDANT_URL**, and **WEATHER_URL**. Create a key for the weather service and then run the following commands to view the service urls.
 
 ```bash
-bx service keys {service_name} #This will output all your service keys
+bx service key-create myweatherinsights {service key} #You can put any name for your {service key}
+bx service keys {service_name} #This will output all your service keys for the {service_name}
 bx service key-show {service_name} {service key} #This will output your service credential, "url" is Your service URL
 ```
 
-Then, run the following commands to build your docker images and run Docker Compose. 
+Then, run the following commands to build your docker images and run Docker Compose.
 
 ```bash
 docker build -f main_application/Dockerfile.local -t flightassist main_application
@@ -140,9 +141,9 @@ docker-compose up
 ```
 Now, your FlightAssist application should be running on http://localhost:3000/
 
-# Deploy microservices leveraging
+# Deploy leveraging different scenarios
 
-Now you know to deploy your application and microservices on your local host. So let's deploy your application and microservices on the cloud with these 4 different scenarios. 
+Now you know to deploy your application and microservices on your local host. So let's deploy your application and microservice on the cloud with these 4 different scenarios.
 
 1. [Cloud Foundry](docs/cloudfoundry.md)
 2. [Kubernetes Cluster](docs/kubernetes.md)
@@ -152,7 +153,7 @@ Now you know to deploy your application and microservices on your local host. So
 
 # How to Use Flightassist
 
-First, you want to [add a trip on TripIt](https://www.tripit.com/trip/create). Then, add a new flight plan for your trip. In your plan, please fill in your confirmation number or airline with flight number.
+To try out Flightassist, you need to [add a trip on TripIt](https://www.tripit.com/trip/create). Then, add at least one flight for your trip with a departure within the next 24 hours. In your plan, please fill in your confirmation number or airline with flight number.
 
 ![Tripit plan](images/plans.png)
 
@@ -162,7 +163,7 @@ Now you can see the most recent flight status and weather for all your flights w
 
 ![Flightassist status](images/status.png)
 
-# Reference 
+# Reference
 
 This project is based on this [flightassist](https://github.com/estesp/flightassist) example.
 

--- a/docs/cloudfoundry.md
+++ b/docs/cloudfoundry.md
@@ -1,12 +1,12 @@
 # Deploy Flightassist microservices on Cloud Foundry
 
-Make sure you have both developer accounts mentioned in prerequisites. Also make sure you have cloudant and weatherinsights services created as listed in [step 1](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#1-create-your-cloudant-database-and-insights-for-weather-service). 
+Make sure you have both developer accounts mentioned in prerequisites. Also make sure you have cloudant and weatherinsights services created as listed in [step 1](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#1-create-your-cloudant-database-and-insights-for-weather-service).
 
-In this scenario, we take the Flightassist which is factored in microservices. Since Cloud Foundry apps (warden containers) are not allowed to talk privately, they need to communicate via public route.
+In this scenario, we take the Flightassist which is factored to use the weather microservice. Since Cloud Foundry apps (warden containers) are not allowed to talk privately, they need to communicate via public route.
 
 We first push the python microservice.
 ```
-bx app push <name1> -f path-to/flightassist-weather/manifest.yml
+bx app push {your_unique_proxy_name} -f flightassist-weather/manifest.yml
 ```
 > Note: If you want to use `cf` commands, please install [cloudfoundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) and replace all the `bx app push` command with `cf push`
 
@@ -17,7 +17,7 @@ The output should look like:
 requested state: started
 instances: 1/1
 usage: 256M x 1 instances
-urls: <name1>.mybluemix.net
+urls: {proxy_name}.mybluemix.net
 last uploaded: Thu Jun 8 21:36:15 UTC 2017
 stack: unknown
 buildpack: python_buildpack
@@ -25,7 +25,7 @@ buildpack: python_buildpack
 And we need the **urls** for next step.   
 Now we will push the second app, but **without starting** it.
 ```
-bx app push <name2> -f path-to/main_application/manifest.yml --no-start
+bx app push {your_unique_app_name} -f main_application/manifest.yml --no-start
 ```
 **make sure you pick a unique name for the app, too.**
 
@@ -38,16 +38,16 @@ Now we inject the environment variables as in monolithic deployment:
 
 Plus, a couple more since we have two apps:
  - `USE_WEATHER_SERVICE`: true
- - `MICROSERVICE_URL`: <i>name1</i>.mybluemix.net
- 
-Now we start the 2nd app:
-`bx app start <name2>`
+ - `MICROSERVICE_URL`: {proxy_name}.mybluemix.net
 
-You can now test the apps by going to http://<i>name2</i>.mybluemix.net
+Now we start the 2nd app:
+`bx app start {app_name}`
+
+You can now test the apps by going to http://{app_name}.mybluemix.net
 
 
 ## Takeaway points
-To push an app, we simply use `bx app push` or `cf push` command. There is no container image or repository involved. Cloud Foundry has wide inventories of build packs to support different programming languages. If you run `cf marketplace`, you can find the huge list of services provided by Bluemix that can easily be consumed by your application. When pushing multi apps that need to communicate to each other, however, it is a little hacky. Another common practice than the environment variables we used in this example, is to bind a message queue service.
+To push an app, we simply use `bx app push` or `cf push` command. There is no container image or repository involved. Cloud Foundry has wide inventories of build packs to support different programming languages. If you run `cf marketplace`, you can find the huge list of services provided by Bluemix that can easily be consumed by your application. When pushing multi apps that need to communicate to each other, however, it is a little hacky. Another common alternative to creating public routes and sharing through environment variables as used in this example, is to bind a message queue service for communication.
 
 # Code Structure
 

--- a/docs/istio.md
+++ b/docs/istio.md
@@ -12,6 +12,7 @@ Then, install the container registry plugin for Bluemix CLI.
 bx plugin install container-registry -r Bluemix
 ```
 Next, build your own docker images and push them to your own bluemix container registry.
+> You may skip these steps through deploying the secrets if you performed the Flightassist microservices deployment on Kubernetes scenario
 
 > Replace `<namespace>` with your own namespace, you can view your namespace by running `bx cr namespaces`
 >
@@ -24,7 +25,7 @@ docker push registry.ng.bluemix.net/<namespace>/flightassist
 docker push registry.ng.bluemix.net/<namespace>/weather-service
 ```
 
-Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters. 
+Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters.
 
 ```bash
 bx cs cluster-service-bind {your-cluster-name} default mycloudant
@@ -86,7 +87,7 @@ istio-mixer-2499357295-kn4vq      1/1       Running   0
 
 ## 3. Inject Istio Envoys on Flightassist.
 
-> Note : you need to delete all the services and deployments from the previous scenario.
+> Note : if you performed the Flightassist microservices deployment on Kubernetes scenario you need to delete the previous services and deployments.
 >
 > ```bash
 > kubectl delete -f flightassist.yaml
@@ -101,23 +102,23 @@ echo $(kubectl get po -l istio=ingress -o jsonpath={.items[0].status.hostIP}):$(
 Then, edit the `flightassist.yaml` and replace the ```<namespace>``` with your own namespace. You can obtain your namespace by running `bx cr namespace`. Also replace `<your-app-end-point-url>` with `http://<isito-ingress IP:Port>`
 > You also can remove `type:NodePort` on *flightassist-service* because we will access our application via isito-ingress.
 
-Next, deploy ingress to connect the microservices and inject Istio envoys on Flightassist and Weather Microservice. 
+Next, deploy ingress to connect the microservices and inject Istio envoys on Flightassist and Weather Microservice.
 
 ```bash
 kubectl create -f ingress.yaml
 kubectl create -f <(istioctl kube-inject -f flightassist.yaml --includeIPRanges=172.30.0.0/16,172.20.0.0/16)
 ```
 
-Congratulation, now your Flightassist application should be running on `http://<isito-ingress IP:Port>`. You can go to [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
+Congratulations, now your Flightassist application should be running on `http://<isito-ingress IP:Port>`. You can go to [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
 
 
 ## 4. Exporing additional features on Istio.
 
 One feature provided by Istio is rate limits. Rate limits can limit the number of accesses from users and prevent your website from getting abused.
 
-To enable this, run 
+To enable this, run
 
-```bash 
+```bash
 istioctl mixer rule create global flightassist-service.default.svc.cluster.local -f ratelimit.yaml
 ```
 
@@ -126,7 +127,7 @@ Now, your rate limit is 50 requests per 10 seconds. Since the flightassist websi
 You can learn about other additional features on Istio by clicking [here](https://istio.io/docs/tasks/index.html).
 
 ## Takeaway points
-Istio is an addon feature to manage your application traffic. It has to reside on a platform. Other than the proxy feature we tested in the example, it also provides rich layer-7 routing, circuit breakers, policy enforcement and telemetry recording/reporting functions.
+Istio is an addon feature to manage your application traffic. It has to reside on a platform. In addition to the proxy feature we tested in the example, it also provides rich layer-7 routing, circuit breakers, policy enforcement and telemetry recording/reporting functions.
 
 
 # Code Structure
@@ -139,5 +140,5 @@ Istio is an addon feature to manage your application traffic. It has to reside o
 | [package.json](../main_application/package.json)         | List the packages required by the application |
 | [Dockerfile.local](../main_application/Dockerfile.local) and [Dockerfile.alpine](../flightassist-weather/Dockerfile.alpine) | Description of the Docker image |
 | [flightassist.yaml](../flightassist.yaml) and [secret.yaml](../secret.yaml)| Specification file for the deployment of the service and secret in Kubernetes |
-| [ingress.yaml](../ingress.yaml)| Specification file for adding flightassist's endpoint to istio-ingress| 
-| [ratelimit.yaml](../ratelimit.yaml) | Specification file for creating rate limits with Istio Mixer| 
+| [ingress.yaml](../ingress.yaml)| Specification file for adding flightassist's endpoint to istio-ingress|
+| [ratelimit.yaml](../ratelimit.yaml) | Specification file for creating rate limits with Istio Mixer|

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,6 +1,6 @@
 # Deploy Flightassist microservices on Kubernetes Cluster
 
-In this scenario, we use the Flightassist microservices in which are in two containers. We will run Flightassist as our main application with weather-service as our microservice to query the weather data. Then, we will host those containers using Kubernetes. 
+In this scenario, we use the Flightassist microservices version which runs in two containers. We will run Flightassist as our main application with weather-service as our microservice to query the weather data. Then, we will host those containers using Kubernetes.
 
 First, follow the [Kubernetes Cluster Tutorial](https://github.com/IBM/container-journey-template) to create your own cluster on Bluemix.
 
@@ -22,7 +22,7 @@ docker push registry.ng.bluemix.net/<namespace>/flightassist
 docker push registry.ng.bluemix.net/<namespace>/weather-service
 ```
 
-Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters. 
+Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters.
 
 ```bash
 bx cs cluster-service-bind {your-cluster-name} default mycloudant
@@ -46,10 +46,10 @@ kubectl create -f secret.yaml
 kubectl create -f flightassist.yaml
 ```
 
-Congratulation, now your Flightassist application should be running on `http://<your_node_ip>:30080`. You can go to [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
+Congratulations, now your Flightassist application should be running on `http://<your_node_ip>:30080`. You can go to [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
 
 ## Takeaway points
-Kubernetes is a powerful orchestration tool. In this example we get a taste of the logical concept of clusters, creating a deployment and service binding. It also has the container networking features built in. However, as a developer, you need to deal with container image and repositories. 
+Kubernetes is a powerful orchestration tool. In this example we get a taste of the logical concept of clusters, creating a deployment and service binding. It also has the container networking features built in. However, as a developer, you need to handle building container images and managing images in repositories. 
 
 
 # Code Structure

--- a/docs/openwhisk.md
+++ b/docs/openwhisk.md
@@ -1,6 +1,6 @@
 # Deploy Flightassist leveraging OpenWhisk functions
 
-In this scenario, we will deploy Flightassist with a function that can query all the necessary Weather data. This shows how you could replace your microservices with OpenWhisk actions. Therefore, you can move all your low cost microservices on OpenWhisk to save space and runtime on your server.
+In this scenario, we will deploy Flightassist to use a function that queries the necessary weather data. This shows how you could implement simple microservices with OpenWhisk. This approach replaces containers with OpenWhisk actions to save space and runtime memory in your cluster. Thanks to OpenWhisk built-in system packages, which includes a weather API, we don't even have to write our own action to implement the weather forecast lookup.
 
 First, follow the [Kubernetes Cluster Tutorial](https://github.com/IBM/container-journey-template) to create your own cluster on Bluemix.
 
@@ -10,6 +10,7 @@ Then, install the container registry plugin for Bluemix CLI.
 bx plugin install container-registry -r Bluemix
 ```
 Next, build your own docker images and push them to your own bluemix container registry.
+> You may skip these steps through deploying the secrets if you performed the Flightassist microservices deployment on Kubernetes or Istio scenarios
 
 > Replace `<namespace>` with your own namespace, you can view your namespace by running `bx cr namespaces`
 >
@@ -22,7 +23,7 @@ docker push registry.ng.bluemix.net/<namespace>/flightassist
 docker push registry.ng.bluemix.net/<namespace>/weather-service
 ```
 
-Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters. 
+Then, you need to run the following commands to bind your Cloudant and Weather Insights services to your clusters.
 
 ```bash
 bx cs cluster-service-bind {your-cluster-name} default mycloudant
@@ -36,7 +37,7 @@ Now, run the following commands to deploy the secret
 kubectl create -f secret.yaml
 ```
 
-> Note : you need to delete all the services and deployments from the previous scenario.
+> Note : you need to delete all the services and deployments from any previous scenarios.
 >
 > ```bash
 > kubectl delete -f flightassist.yaml
@@ -46,16 +47,16 @@ Then, install [OpenWhisk CLI](https://console.ng.bluemix.net/openwhisk/learn/cli
 
 Next, edit `flightassist_serverless.yaml` and replace the `<namespace>` with your own namespace, `<your-app-end-point-url>` with your node ip and nodeport, and `<your-openwhisk-auth>` with your OpenWhisk authentication. You can run `wsk property get --auth | awk '{print $3}'` to view your OpenWhisk authentication.
 
-Now, let's deploy the new flightassist app with serverless capability
+Now, let's deploy the new Flightassist app with serverless capability
 
 ```bash
 kubectl create -f flightassist_serverless.yaml
 ```
 
-Congratulation, now your Flightassist application should be running on `http://<your_node_ip>:30080`. Also, you can learn about [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
+Congratulations, now your Flightassist application should be running on `http://<your_node_ip>:30080`. Also, you can learn about [How to Use Flightassist](https://github.com/IBM/Microservices-deployment-with-PaaS-Containers-and-Serverless-Platforms#how-to-use-flightassist) and start testing your application.
 
 ## Takeaway points
-In this example, the flightassist app is a perfect use case to use openwhisk: 
+In this example, the weather microservice in the Flightassist app is a perfect use case to use OpenWhisk:
 1. It is an event triggered app, the triggering point is when it is accessed
 2. It is a stateless app, there are no sessions to manage
 3. It doesn't require persistence


### PR DESCRIPTION
General updates for grammar and style. 
Add step to create credentials for weather service.
Match style in Cloud Foundry microservice naming e.g. {app_name} with previous CF example. 
Update conditions for skipping steps in container-based scenarios if other prior scenarios have been completed.